### PR TITLE
disabled Parse command

### DIFF
--- a/pgpool2/pool_proto_modules.c
+++ b/pgpool2/pool_proto_modules.c
@@ -896,6 +896,9 @@ POOL_STATUS Parse(POOL_CONNECTION *frontend, POOL_CONNECTION_POOL *backend,
 	POOL_SESSION_CONTEXT *session_context;
 	POOL_QUERY_CONTEXT *query_context;
 
+	pool_error("Parse: Prestogres doesn't support extended query");
+	return POOL_END;
+
 	/* Get session context */
 	session_context = pool_get_session_context();
 	if (!session_context)
@@ -1031,16 +1034,6 @@ POOL_STATUS Parse(POOL_CONNECTION *frontend, POOL_CONNECTION_POOL *backend,
 		 */
 		pool_where_to_send(query_context, query_context->original_query,
 						   query_context->parse_tree);
-		{
-			int alloc_len = len - strlen(stmt) + strlen(query_context->original_query);
-			contents = palloc(alloc_len);
-			strcpy(contents, name);
-			strcpy(contents + strlen(name) + 1, query_context->original_query);
-			memcpy(contents + strlen(name) + 1 + strlen(query_context->original_query) + 1,
-					stmt + strlen(stmt) + 1,
-					len - (strlen(name) + 1 + strlen(stmt) + 1));
-			len = alloc_len;
-		}
 
 		if (REPLICATION)
 		{


### PR DESCRIPTION
Extended query doesn't work at all with Prestogres. This patch kills child process immediately when it gets Parse command.
