### PR TITLE
I think that "root" execution of the PostgreSQL server is not permitted.

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ $ prestogres-ctl create pgdata
 # vi pgdata/postgresql.conf  # edit configuration if necessary
 
 # 3. Start PostgreSQL
-$ sudo prestogres-ctl postgres -D pgdata
+$ prestogres-ctl postgres -D pgdata
 
 # 4. Open another shell, and initialize the database to install PL/Python functions
 $ prestogres-ctl migrate


### PR DESCRIPTION
The console log is the following.

$ sudo prestogres-ctl postgres -D pgdata
which: no postgres in (/usr/bin:/bin:/usr/sbin:/sbin)
env PYTHONPATH=/usr/local/share/prestogres postgres -D pgdata
env: postgres: No such file or directory
$ sudo -E prestogres-ctl postgres -D pgdata
env PYTHONPATH=/usr/local/share/prestogres /usr/pgsql-9.3/bin/postgres -D pgdata
"root" execution of the PostgreSQL server is not permitted.
The server must be started under an unprivileged user ID to prevent
possible system security compromise.  See the documentation for
more information on how to properly start the server.
$ prestogres-ctl postgres -D pgdata
env PYTHONPATH=/usr/local/share/prestogres /usr/pgsql-9.3/bin/postgres -D pgdata
< 2015-02-06 09:54:49.288 JST >LOG:  could not create IPv6 socket: Address family not supported by protocol
< 2015-02-06 09:54:49.298 JST >LOG:  redirecting log output to logging collector process
< 2015-02-06 09:54:49.298 JST >HINT:  Future log output will appear in directory "pg_log".

My environment is CentOS 6.5