### PR TITLE
config error occurs at CentOS 6.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ brew install postgresql
 Download the latest release from [releases](https://github.com/treasure-data/prestogres/releases) or clone the [git repository](https://github.com/treasure-data/prestogres). You can install the binary as following:
 
 ```
-$ ./configure --program-prefix=prestogres-
+$ ./configure --program-prefix=prestogres- # if error occurs, add PostgreSQL binary to PATH(for example, export PATH=/usr/pgsql-9.3/bin:$PATH)
 $ make
 $ sudo make install
 ```


### PR DESCRIPTION
configure: error: libpq is not installed or libpq is old