### PR TITLE
Hide temporary created pg_roles by Prestogres

### DIFF
--- a/prestogres/pgsql/setup.sql
+++ b/prestogres/pgsql/setup.sql
@@ -36,6 +36,9 @@ begin
         security definer;
 
         revoke temporary on database "' || target_db || E'" from public;  -- reject CREATE TEMPORARY TABLE
+        revoke select on pg_catalog.pg_roles from public;
+        revoke select on pg_catalog.pg_authid from public;
+        revoke select on pg_catalog.pg_auth_members from public;
         grant usage on schema prestogres_catalog to "' || access_role || E'";
         grant execute on all functions in schema prestogres_catalog to "' || access_role || E'";
 


### PR DESCRIPTION
Prestogres creates several roles at pg_catalog, but these roles are only for internal use. This commit will forbid accesses to these pg_role data. 