### PR TITLE
Do not drop 'public' schema in setup_system_catalog

### DIFF
--- a/prestogres/pgsql/prestogres.py
+++ b/prestogres/pgsql/prestogres.py
@@ -311,9 +311,9 @@ def setup_system_catalog(presto_server, presto_user, presto_catalog, presto_sche
         columns.append(Column(column_name, column_type, is_nullable))
 
     # drop all schemas excepting prestogres_catalog, information_schema and pg_%
-    sql = "select n.nspname as schema_name from pg_catalog.pg_namespace n" \
-          " where n.nspname not in ('prestogres_catalog', 'information_schema')" \
-          " and n.nspname not like 'pg_%'"
+    sql = ("select n.nspname as schema_name from pg_catalog.pg_namespace n "
+           "where n.nspname not in ('prestogres_catalog', 'information_schema') "
+           "and n.nspname not like 'pg_%'  and n.nspname != 'public'")
     for row in plpy.cursor(sql):
         plpy.execute("drop schema %s cascade" % plpy.quote_ident(row["schema_name"]))
 


### PR DESCRIPTION
It appears Prestogres requires prestogres_init_database on every connection.
This is created in the 'public' schema when using 'prestogres-ctl migrate'. If the 'public' schema is dropped then we lose this function.
