### PR TITLE
Remove code that improperly calls pool_unread

### DIFF
--- a/src/context/pool_query_context.c
+++ b/src/context/pool_query_context.c
@@ -875,14 +875,6 @@ POOL_STATUS pool_send_and_wait(POOL_QUERY_CONTEXT *query_context,
                                                    MASTER_CONNECTION(backend)->pid,
                                                    MASTER_CONNECTION(backend)->key);
         
-		/*
-		 * Check if some error detected.  If so, emit
-		 * log. This is useful when invalid encoding error
-		 * occurs. In this case, PostgreSQL does not report
-		 * what statement caused that error and make users
-		 * confused.
-		 */		
-		per_node_error_log(backend, i, string, "pool_send_and_wait: Error or notice message from backend: ", true);
 	}
 
 	return POOL_CONTINUE;
@@ -1058,15 +1050,6 @@ POOL_STATUS pool_extended_send_and_wait(POOL_QUERY_CONTEXT *query_context,
                                                    MAJOR(backend),
                                                    MASTER_CONNECTION(backend)->pid,
                                                    MASTER_CONNECTION(backend)->key);
-
-		/*
-		 * Check if some error detected.  If so, emit
-		 * log. This is useful when invalid encoding error
-		 * occurs. In this case, PostgreSQL does not report
-		 * what statement caused that error and make users
-		 * confused.
-		 */		
-		per_node_error_log(backend, i, str, "pool_send_and_wait: Error or notice message from backend: ", true);
 	}
 
 	if(rewritten_begin)


### PR DESCRIPTION
Presto queries may result in outputs that contain multiple
\0 or NULL characters.  As a result, a single error
message or notice may contain multiple \0 delimited
strings which would get read at once on invocation to
per_node_error_log(), which then attempts to 'unread'
the contents it just read.  However, the pool_unread invocation
ends up unreading up to the first \0 character, and it
does not unread the full message, causing subsequent
calls to getting the postgres message kind to fail
as the kind ends up being a \0 character.