### PR TITLE
Fix Presto RESTful API link traverse ending early

### DIFF
--- a/prestogres/pgsql/presto_client.py
+++ b/prestogres/pgsql/presto_client.py
@@ -305,17 +305,19 @@ class Query(object):
         if self.columns() is None:
             raise PrestoException("Query %s has no columns" % client.results.id)
 
+
         while True:
-            if client.results.data is None:
+            if client.results.data is None and client.results.next_uri is None:
                 break
 
-            for row in client.results.data:
-                yield row
+            if client.results.data is not None:
+                for row in client.results.data:
+                    yield row
 
             if not client.advance():
                 break
 
-            if client.results.data is None:
+            if client.results.next_uri is None and client.results.data is None:
                 break
 
     def cancel(self):


### PR DESCRIPTION
If data comes back as None because presto is slow, then the client prematurely terminates. This fix makes sure termination only occurs after the database is truly done.