### PR TITLE
Convert tinyint to integer because postgresql does't support tinyint

### DIFF
--- a/prestogres/pgsql/prestogres.py
+++ b/prestogres/pgsql/prestogres.py
@@ -25,6 +25,8 @@ def _pg_result_type(presto_type):
         return "double precision"
     elif JSON_TYPE_PATTERN.match(presto_type):
         return "json"  # TODO record or anyarray???
+    elif presto_type == "tinyint":
+        return "integer"
     else:
         # assuming Presto and PostgreSQL use the same SQL standard name
         return presto_type
@@ -39,6 +41,8 @@ def _pg_table_type(presto_type):
         return "double precision"
     elif JSON_TYPE_PATTERN.match(presto_type):
         return "json"  # TODO record or anyarray???
+    elif presto_type == "tinyint":
+        return "integer"
     else:
         # assuming Presto and PostgreSQL use the same SQL standard name
         return presto_type


### PR DESCRIPTION
Presto 0.148 supports  the TINYINT type.

https://prestodb.io/docs/current/release/release-0.148.html

Because postgresql does't support tinyint, the followining error occurs.
- pgdata/pg_log/postgresql-Mon.log 

```
< 2016-06-20 16:26:35.763 JST >ERROR:  spiexceptions.UndefinedObject: type "tinyint" does not exist at character 84
< 2016-06-20 16:26:35.763 JST >QUERY:  create table hoge.test (
          ...
          aaa tinyint,
          ...
        )
< 2016-06-20 16:26:35.763 JST >CONTEXT:  Traceback (most recent call last):
          PL/Python function "setup_system_catalog", line 4, in <module>
            presto_server, presto_user, presto_catalog, presto_schema, access_role)
          PL/Python function "setup_system_catalog", line 329, in setup_system_catalog
        PL/Python function "setup_system_catalog"
```

Prior to 0.148, presto returns integer type if there is the tinyint type.
So the error doesn't occur.
