### PR TITLE
Add check next_uri because presto 0.153 may have no data but have data in next_uri

### DIFF
--- a/prestogres/pgsql/presto_client.py
+++ b/prestogres/pgsql/presto_client.py
@@ -306,16 +306,17 @@ class Query(object):
             raise PrestoException("Query %s has no columns" % client.results.id)
 
         while True:
-            if client.results.data is None:
+            if client.results.data is None and client.results.next_uri is None:
                 break
 
-            for row in client.results.data:
-                yield row
+            if client.results.data is not None:
+                for row in client.results.data:
+                    yield row
 
             if not client.advance():
                 break
 
-            if client.results.data is None:
+            if client.results.data is None and client.results.next_uri is None:
                 break
 
     def cancel(self):


### PR DESCRIPTION
In my environment, I use pentaho and access presto through prestogres.

In presto 0.153, presto 0.154, there is a case without data but has next_uri.

for example,

http://.../1
there is data
http://.../2
there is data
http://.../3
there is no data
http://.../4
there is data
...

In this case, prestogres seems to cancel `http://.../4` wrongly.

I check https://github.com/prestodb/presto/wiki/HTTP-Protocol

So I think that prestogres should check next_uri.

Thanks
