### PR TITLE
Include stdint.h to fix compile error gcc version 7.3.0

### DIFF
--- a/src/watchdog/wd_lifecheck.c
+++ b/src/watchdog/wd_lifecheck.c
@@ -22,6 +22,7 @@
  */
 #include <pthread.h>
 #include <stdio.h>
+#include <stdint.h>
 #include <errno.h>
 #include <ctype.h>
 #include <time.h>

--- a/src/watchdog/wd_ping.c
+++ b/src/watchdog/wd_ping.c
@@ -23,6 +23,7 @@
 
 #include <pthread.h>
 #include <stdio.h>
+#include <stdint.h>
 #include <errno.h>
 #include <string.h>
 #include <stdlib.h>


### PR DESCRIPTION
Does not compile on Ubuntu 18.04 gcc 7.3.0.